### PR TITLE
fix: Task to Task<bool> in DisplayAlert

### DIFF
--- a/src/MauiMicroMvvm/IPageDialogs.cs
+++ b/src/MauiMicroMvvm/IPageDialogs.cs
@@ -6,9 +6,9 @@ public interface IPageDialogs
 
     Task DisplayAlert(string title, string message, string cancel, FlowDirection flowDirection);
 
-    Task DisplayAlert(string title, string message, string accept, string cancel);
+    Task<bool> DisplayAlert(string title, string message, string accept, string cancel);
 
-    Task DisplayAlert(string title, string message, string accept, string cancel, FlowDirection flowDirection);
+    Task<bool> DisplayAlert(string title, string message, string accept, string cancel, FlowDirection flowDirection);
 
     Task<string> DisplayActionSheet(string title, string cancel, string destruction, params string[] buttons);
 

--- a/src/MauiMicroMvvm/Internals/PageDialogs.cs
+++ b/src/MauiMicroMvvm/Internals/PageDialogs.cs
@@ -21,9 +21,9 @@ internal class PageDialogs : IPageDialogs
     public Task DisplayAlert(string title, string message, string cancel, FlowDirection flowDirection) =>
         _shell.DisplayAlert(title, message, cancel, flowDirection);
 
-    public Task DisplayAlert(string title, string message, string accept, string cancel) =>
+    public Task<bool> DisplayAlert(string title, string message, string accept, string cancel) =>
         _shell.DisplayAlert(title, message, accept, cancel);
 
-    public Task DisplayAlert(string title, string message, string accept, string cancel, FlowDirection flowDirection) =>
+    public Task<bool> DisplayAlert(string title, string message, string accept, string cancel, FlowDirection flowDirection) =>
         _shell.DisplayAlert(title, message, accept, cancel, flowDirection);
 }


### PR DESCRIPTION
To fit the underlying .NET MAUI Shell DisplayAlert implementation. #8 