### PR TITLE
fix: later initialization of shell and keeping resources alive

### DIFF
--- a/src/MauiMicroMvvm/MauiMicroBuilderExtensions.cs
+++ b/src/MauiMicroMvvm/MauiMicroBuilderExtensions.cs
@@ -21,10 +21,7 @@ public static class MauiMicroBuilderExtensions
             .AddSingleton<TApp>()
             .AddSingleton<IApplication>(sp =>
             {
-                var app = sp.GetRequiredService<TApp>();
-                var shell = sp.GetRequiredService<Shell>();
-                app.Resources = resources;
-                app.MainPage = shell;
+                var app = sp.GetRequiredService<TApp>();                
 
                 if (mergedDictionaries.Any())
                 {
@@ -44,9 +41,17 @@ public static class MauiMicroBuilderExtensions
 {string.Join('\n', qualifiedResources)}
   </ResourceDictionary.MergedDictionaries>
 </ResourceDictionary>";
-                    app.Resources.LoadFromXaml(xaml);
+                    
+                    app.Resources.LoadFromXaml(xaml);                    
                 }
 
+                if (resources != null && resources.Keys.Any())
+                {
+                    app.Resources.Add(resources);
+                }
+
+                var shell = sp.GetRequiredService<Shell>();
+                app.MainPage = shell;
                 return app;
             });
 


### PR DESCRIPTION
Order of execution changes: If Shell uses static resources for example in FlyoutItems, then the shell has to be initialized later than the addition of the resources to the app.
Change of how the ResourceDictionary is added: Avoids the overwriting of resources which already might exist (for example if defined in a separate App.xaml)

#10 