### PR TITLE
ci: update GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,11 @@ on:
     paths:
       - "sample/**"
       - "src/**"
-      - "test/**"
+      - "tests/**"
+      - "Directory.Build.props"
+      - "Directory.Build.targets"
+      - "Directory.Packages.props"
+      - "MauiMicroMvvm.sln"
       - "version.json"
       - "build.slnf"
       - ".github/workflows/ci.yml"
@@ -18,6 +22,7 @@ jobs:
     with:
       name: MauiMicroMvvm
       solution-path: build.slnf
+      dotnet-version: 8.0.x
       install-workload: maui
       code-sign: true
     secrets:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '15.2'
+          xcode-version: 'latest-stable'
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.0.x

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,15 +26,19 @@ jobs:
 
   validate:
     needs: [build]
-    runs-on: macos-15
+    runs-on: macos-14
     steps:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest-stable
+          xcode-version: '15.2'
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.0.x
+      - name: Pin .NET SDK for template validation
+        run: |
+          SDK_VERSION=$(dotnet --list-sdks | awk '/^8\./ { version=$1 } END { print version }')
+          dotnet new globaljson --sdk-version "$SDK_VERSION" --roll-forward latestFeature
       - name: Download Artifacts
         uses: actions/download-artifact@v8
         with:
@@ -50,5 +54,5 @@ jobs:
         run: dotnet workload install maui
         working-directory: TestProject
       - name: Build Project
-        run: dotnet build
+        run: dotnet build -f net8.0-maccatalyst -p:MauiVersion=8.0.3
         working-directory: TestProject

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,7 +6,11 @@ on:
     paths:
       - "sample/**"
       - "src/**"
-      - "test/**"
+      - "tests/**"
+      - "Directory.Build.props"
+      - "Directory.Build.targets"
+      - "Directory.Packages.props"
+      - "MauiMicroMvvm.sln"
       - "version.json"
       - "build.slnf"
       - ".github/workflows/pr.yml"
@@ -17,21 +21,22 @@ jobs:
     with:
       name: MauiMicroMvvm
       solution-path: build.slnf
+      dotnet-version: 8.0.x
       install-workload: maui
 
   validate:
     needs: [build]
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '15.2'
-      - uses: actions/setup-dotnet@v4
+          xcode-version: latest-stable
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.0.x
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v8
         with:
           name: NuGet
           path: Artifacts

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -9,6 +9,7 @@ jobs:
     with:
       name: MauiMicroMvvm
       solution-path: build.slnf
+      dotnet-version: 8.0.x
       install-workload: maui
       code-sign: true
     secrets:


### PR DESCRIPTION
## Summary
- updates direct GitHub Actions in PR validation to current supported major versions
- refreshes PR validation macOS/Xcode selection and pins reusable dotnet-build calls to .NET 8.x for the current repo state
- fixes workflow path filters so build/package files and tests changes trigger CI

## Notes
- Scope is workflow-only; no project/package/TFM/source files changed.
- Reusable AvantiPoint workflow-template fixes/pinning still belong in a separate workflow-templates PR/release before this repo stops consuming @master.
- .NET 10 project/package/TFM modernization remains intentionally out of this PR.

## Verification
- actionlint .github/workflows/*.yml
- act -l pull_request
- act pull_request -W .github/workflows/pr.yml -n (act skipped windows-latest reusable build without -P; local act 0.2.74 also reports CVE warning)
- act -l push
- act push -W .github/workflows/ci.yml -n (same windows-latest limitation)